### PR TITLE
Fix duplicate words in comments

### DIFF
--- a/Source/ACE.Common/OfflineConfiguration.cs
+++ b/Source/ACE.Common/OfflineConfiguration.cs
@@ -60,7 +60,7 @@ namespace ACE.Common
         /// <summary>
         /// When AutoApplyWorldCustomizations is set to true, the auto apply process will search for
         /// all .sql files in the following directories.
-        /// This process will still use ./Content by default, or the the config_properties_string
+        /// This process will still use ./Content by default, or the config_properties_string
         /// value for 'content_folder' if it exists
         /// </summary>
         public string[] WorldCustomizationAddedPaths { get; set; } = { };

--- a/Source/ACE.Server/Config.js.docker
+++ b/Source/ACE.Server/Config.js.docker
@@ -213,7 +213,7 @@
 
     // When AutoApplyWorldCustomizations is set to true, the auto apply process will search for
     // all .sql files in the following directories.
-    // This process will still use ./Content by default, or the the config_properties_string
+    // This process will still use ./Content by default, or the config_properties_string
     // value for 'content_folder' if it exists
     // Example: [ "C:\\MyContent", "C:\\FTPRoot\\Editor1Content", "C:\\FTPRoot\\Editor2Content" ]
     "WorldCustomizationAddedPaths": [],

--- a/Source/ACE.Server/Config.js.example
+++ b/Source/ACE.Server/Config.js.example
@@ -214,7 +214,7 @@
 
     // When AutoApplyWorldCustomizations is set to true, the auto apply process will search for
     // all .sql files in the following directories.
-    // This process will still use ./Content by default, or the the config_properties_string
+    // This process will still use ./Content by default, or the config_properties_string
     // value for 'content_folder' if it exists
     // Example: [ "C:\\MyContent", "C:\\FTPRoot\\Editor1Content", "C:\\FTPRoot\\Editor2Content" ]
     "WorldCustomizationAddedPaths": [],

--- a/Source/ACE.Server/WorldObjects/Player_Networking.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Networking.cs
@@ -24,7 +24,7 @@ namespace ACE.Server.WorldObjects
             PlayerManager.SwitchPlayerFromOfflineToOnline(this);
             Teleporting = true;
 
-            // Save the the LoginTimestamp
+            // Save the LoginTimestamp
             var lastLoginTimestamp = Time.GetUnixTime();
 
             LoginTimestamp = lastLoginTimestamp;


### PR DESCRIPTION
## Summary
- clean up doubled "the" words in OfflineConfiguration, Config.js templates, and Player_Networking

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68433063070c83309f42000ee49e7b21