### PR TITLE
Fix access level update for missing accounts

### DIFF
--- a/Source/ACE.Database.Tests/AccountTests.cs
+++ b/Source/ACE.Database.Tests/AccountTests.cs
@@ -80,5 +80,12 @@ namespace ACE.Database.Tests
             Assert.IsNotNull(results);
             Assert.IsFalse(results.PasswordMatches("testpassword2"));
         }
+
+        [TestMethod]
+        public void UpdateAccountAccessLevel_InvalidId_ReturnsFalse()
+        {
+            var result = authDb.UpdateAccountAccessLevel(uint.MaxValue, AccessLevel.Player);
+            Assert.IsFalse(result);
+        }
     }
 }

--- a/Source/ACE.Database/AuthenticationDatabase.cs
+++ b/Source/ACE.Database/AuthenticationDatabase.cs
@@ -129,7 +129,7 @@ namespace ACE.Database
             using (var context = new AuthDbContext())
             {
                 var account = context.Account
-                    .First(r => r.AccountId == accountId);
+                    .FirstOrDefault(r => r.AccountId == accountId);
 
                 if (account == null)
                     return false;


### PR DESCRIPTION
## Summary
- guard account lookup with `FirstOrDefault`
- test `UpdateAccountAccessLevel` when id doesn't exist

AuthenticationDatabase.UpdateAccountAccessLevel queries accounts with First(...) and later checks for null, but First throws when no match exists. This will crash when an invalid accountId is supplied.