### PR TITLE
Fix reportbug description trimming

### DIFF
--- a/Source/ACE.Server.Tests/Command/ReportbugTests.cs
+++ b/Source/ACE.Server.Tests/Command/ReportbugTests.cs
@@ -14,5 +14,13 @@ namespace ACE.Server.Tests.Command
             Assert.IsTrue(PlayerCommands.ReportbugCategoryRequiresObject("item"));
             Assert.IsFalse(PlayerCommands.ReportbugCategoryRequiresObject("quest"));
         }
+
+        [TestMethod]
+        public void NormalizeBugDescription_TrimsWhitespace()
+        {
+            const string description = "test bug description   ";
+            var normalized = PlayerCommands.NormalizeBugDescription(description);
+            Assert.AreEqual("test bug description", normalized);
+        }
     }
 }

--- a/Source/ACE.Server/Command/Handlers/PlayerCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/PlayerCommands.cs
@@ -419,7 +419,7 @@ namespace ACE.Server.Command.Handlers
             for (var i = 1; i < parameters.Length; i++)
                 description += parameters[i] + " ";
 
-            description.Trim();
+            description = NormalizeBugDescription(description);
 
             switch (category.ToLower())
             {
@@ -528,6 +528,11 @@ namespace ACE.Server.Command.Handlers
         {
             var cg = category.ToLower();
             return cg == "creature" || cg == "npc" || cg == "item";
+        }
+
+        public static string NormalizeBugDescription(string description)
+        {
+            return description.Trim();
         }
     }
 }


### PR DESCRIPTION
## Summary
In PlayerCommands.HandleReportbug, the line description.Trim(); doesn’t assign the trimmed result, leaving trailing spaces in the description.

- trim reportbug description properly
- expose NormalizeBugDescription helper and unit test it
