### PR TITLE
Make RetryWrite async

### DIFF
--- a/Source/ACE.Server.Tests/ModHelperTests.cs
+++ b/Source/ACE.Server.Tests/ModHelperTests.cs
@@ -1,0 +1,30 @@
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ACE.Server.Mods;
+
+namespace ACE.Server.Tests
+{
+    [TestClass]
+    public class ModHelperTests
+    {
+        [TestMethod]
+        public async Task RetryWrite_FailsWhenFileLocked()
+        {
+            var path = Path.GetTempFileName();
+            var file = new FileInfo(path);
+
+            try
+            {
+                using var stream = new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+                var result = await file.RetryWrite("data", 1);
+                Assert.IsFalse(result);
+            }
+            finally
+            {
+                if (File.Exists(path))
+                    File.Delete(path);
+            }
+        }
+    }
+}

--- a/Source/ACE.Server/Mods/ModCommands.cs
+++ b/Source/ACE.Server/Mods/ModCommands.cs
@@ -123,22 +123,22 @@ namespace ACE.Server.Command.Handlers
         /// <summary>
         /// Disable Mod and save choice in Metadata
         /// </summary>
-        private static void DisableMod(Session session, ModContainer match)
+        private static async void DisableMod(Session session, ModContainer match)
         {
             Log($"Disabling {match.Meta.Name}", session);
             match.Meta.Enabled = false;
-            match.SaveMetadata();
+            await match.SaveMetadata();
             match.Disable();
         }
 
         /// <summary>
         /// Enable Mod and save choice in Metadata
         /// </summary>
-        private static void EnableMod(Session session, ModContainer match)
+        private static async void EnableMod(Session session, ModContainer match)
         {
             Log($"Enabling {match.Meta.Name}", session);
             match.Meta.Enabled = true;
-            match.SaveMetadata();
+            await match.SaveMetadata();
             match.Enable();
         }
 

--- a/Source/ACE.Server/Mods/ModContainer.cs
+++ b/Source/ACE.Server/Mods/ModContainer.cs
@@ -9,6 +9,7 @@ using System;
 using System.IO;
 using System.Reflection;
 using System.Text.Json;
+using System.Threading.Tasks;
 
 namespace ACE.Server.Mods
 {
@@ -211,12 +212,12 @@ namespace ACE.Server.Mods
             return true;
         }
 
-        public void SaveMetadata()
+        public async Task SaveMetadata()
         {
             var json = JsonSerializer.Serialize(Meta, ConfigManager.SerializerOptions);
             var info = new FileInfo(MetadataPath);
 
-            if (!info.RetryWrite(json))
+            if (!await info.RetryWrite(json))
                 log.Error($"Saving metadata failed: {MetadataPath}");
         }
 

--- a/Source/ACE.Server/Mods/ModHelpers.cs
+++ b/Source/ACE.Server/Mods/ModHelpers.cs
@@ -150,11 +150,11 @@ namespace ACE.Server.Mods
         /// Attempts every second for a number of tries to write to a file.
         /// </summary>
         /// <returns>True if content was successfully written to file</returns>
-        public static bool RetryWrite(this FileInfo file, string content, int retryCount = 5)
+        public static async Task<bool> RetryWrite(this FileInfo file, string content, int retryCount = 5)
         {
             try
             {
-                Task.Run(async () => await file.WriteWithRetryAsync(TimeSpan.FromSeconds(1), content, retryCount));
+                await file.WriteWithRetryAsync(TimeSpan.FromSeconds(1), content, retryCount);
             }
             catch (Exception)
             {


### PR DESCRIPTION
## Summary
- allow awaiting WriteWithRetryAsync by changing `RetryWrite` to return a task
- update mod metadata save helpers to await new method
- adjust command helpers to be async so metadata is persisted
- add regression test for failure propagation when writes cannot complete
