### PR TITLE
Fix env cell visibility when no cells

### DIFF
--- a/Source/ACE.Server.Tests/Physics/EnvCellTests.cs
+++ b/Source/ACE.Server.Tests/Physics/EnvCellTests.cs
@@ -1,0 +1,35 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ACE.Server.Physics.Common;
+using System.Collections.Generic;
+using System.Collections.Concurrent;
+
+namespace ACE.Server.Tests.Physics
+{
+    [TestClass]
+    public class EnvCellTests
+    {
+        [TestMethod]
+        public void GetVisible_ReturnsNull_WhenNoVisibleCells()
+        {
+            uint cellId = 0xDEAD0001;
+            uint landblockKey = cellId | 0xFFFF;
+
+            var landblock = new Landblock();
+            landblock.ID = cellId & 0xFFFF0000;
+            landblock.LandCells = new ConcurrentDictionary<int, ObjCell>();
+
+            var envCell = new EnvCell();
+            envCell.ID = cellId;
+            envCell.VisibleCells = new Dictionary<uint, EnvCell>();
+
+            landblock.LandCells[(int)(cellId & 0xFFFF)] = envCell;
+            LScape.Landblocks[landblockKey] = landblock;
+
+            var visible = EnvCell.get_visible(cellId);
+
+            Assert.IsNull(visible);
+
+            LScape.Landblocks.TryRemove(landblockKey, out _);
+        }
+    }
+}

--- a/Source/ACE.Server/Physics/Common/EnvCell.cs
+++ b/Source/ACE.Server/Physics/Common/EnvCell.cs
@@ -406,7 +406,7 @@ namespace ACE.Server.Physics.Common
         public static ObjCell get_visible(uint cellID)
         {
             var cell = (EnvCell)LScape.get_landcell(cellID);
-            return cell.VisibleCells.Values.First();
+            return cell.VisibleCells.Values.FirstOrDefault();
         }
 
         public void grab_visible(List<uint> stabs)


### PR DESCRIPTION
## Summary
- avoid invalid access when an env cell has no visible cells
- test EnvCell.get_visible with no visible cells
