### PR TITLE
Fix resource handling in ModHelpers ReadWithRetryAsync

### DIFF
--- a/Source/ACE.Server.Tests/ModHelpersTests.cs
+++ b/Source/ACE.Server.Tests/ModHelpersTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using HarmonyLib;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ACE.Server.Mods;
+
+namespace ACE.Server.Tests
+{
+    [TestClass]
+    public class ModHelpersTests
+    {
+        private static bool _shouldThrow = true;
+
+        [TestMethod]
+        public async Task ReadWithRetryAsync_ClosesFile_OnException()
+        {
+            var path = Path.GetTempFileName();
+            await File.WriteAllTextAsync(path, "data");
+            var file = new FileInfo(path);
+
+            var harmony = new Harmony("ModHelpersTests.ReadFailure");
+            harmony.Patch(
+                AccessTools.Method(typeof(StreamReader), nameof(StreamReader.ReadToEndAsync)),
+                prefix: new HarmonyMethod(typeof(ModHelpersTests).GetMethod(nameof(FailPrefix), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static))
+            );
+
+            try
+            {
+                await Assert.ThrowsExceptionAsync<InvalidOperationException>(async () => await file.ReadWithRetryAsync(TimeSpan.FromMilliseconds(1), 1));
+            }
+            finally
+            {
+                harmony.UnpatchAll(harmony.Id);
+            }
+
+            using (var fs = new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+            {
+            }
+
+            File.Delete(path);
+        }
+
+        private static bool FailPrefix(ref Task<string> __result)
+        {
+            if (_shouldThrow)
+            {
+                _shouldThrow = false;
+                __result = Task.FromException<string>(new InvalidOperationException("fail"));
+                return false;
+            }
+            return true;
+        }
+    }
+}

--- a/Source/ACE.Server/Mods/ModHelpers.cs
+++ b/Source/ACE.Server/Mods/ModHelpers.cs
@@ -222,11 +222,10 @@ namespace ACE.Server.Mods
                 try
                 {
                     //Get a stream.  OpenRead only allows read share
-                    StreamReader reader = new(file.OpenRead());
+                    using var reader = new StreamReader(file.OpenRead());
 
                     //Return stream if there's no problem
                     var content = await reader.ReadToEndAsync();
-                    reader.Close();
                     return content;
                 }
                 //https://learn.microsoft.com/en-us/dotnet/standard/io/handling-io-errors


### PR DESCRIPTION
## Summary
- dispose `StreamReader` using a `using` statement in `ReadWithRetryAsync`
- add regression test ensuring the file handle is closed when `ReadToEndAsync` throws
