### PR TITLE
Fix start_server net8 path and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Extended documentation can be found on the project [Wiki](https://github.com/ACE
 * [Developing ACE](https://github.com/ACEmulator/ACE/wiki/ACE-Development)
 * [Hosting ACE](https://github.com/ACEmulator/ACE/wiki/ACE-Hosting)
 * [Content Creation](https://github.com/ACEmulator/ACE/wiki/Content-Creation)
+* After building, run `start_server.bat` from the output directory (e.g. `bin\x64\Debug\net8.0\`) to launch the server using `dotnet ACE.Server.dll`.
 
 ## Contributions
 * Contributions in the form of issues and pull requests are welcomed and encouraged.

--- a/Source/ACE.Server/start_server.bat
+++ b/Source/ACE.Server/start_server.bat
@@ -1,4 +1,4 @@
 @cd %~dp0
-@if not exist "ACE.Server.dll" (echo please run the copy of this file residing in the output folder: .\bin\x64\XXXXX\netcoreapp2.2\
+@if not exist "ACE.Server.dll" (echo please run the copy of this file residing in the output folder: .\bin\x64\XXXXX\net8.0\
 pause)
 dotnet ACE.Server.dll


### PR DESCRIPTION
## Summary
- point `start_server.bat` to `net8.0`
- document the new output folder and command in README

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68487ef511108330892f8b94dcb0e157