### PR TITLE
Update start_server.sh for .NET 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Extended documentation can be found on the project [Wiki](https://github.com/ACE
 * [Hosting ACE](https://github.com/ACEmulator/ACE/wiki/ACE-Hosting)
 * [Content Creation](https://github.com/ACEmulator/ACE/wiki/Content-Creation)
 
+Run the server using `start_server.bat` on Windows or `start_server.sh` on
+Linux/macOS.
+
 ## Contributions
 * Contributions in the form of issues and pull requests are welcomed and encouraged.
 * The preferred way to contribute is to fork the repo and submit a pull request on GitHub.

--- a/Source/ACE.Server/ACE.Server.csproj
+++ b/Source/ACE.Server/ACE.Server.csproj
@@ -283,6 +283,9 @@
     <None Update="start_server.bat">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="start_server.sh">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/ACE.Server/start_server.sh
+++ b/Source/ACE.Server/start_server.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+cd "$(dirname "$0")"
+if [ ! -f ACE.Server.dll ]; then
+  echo "please run the copy of this file residing in the output folder: ./bin/x64/XXXXX/net8.0/"
+  read -p "Press enter to continue..." dummy
+fi
+exec dotnet ACE.Server.dll


### PR DESCRIPTION
## Summary
- update path in `start_server.sh` to match .NET 8 output

## Testing
- `dotnet test Source/ACE.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68487fc946b48330a30b9515d4509580