### PR TITLE
Fix logging initialization

### DIFF
--- a/Source/ACE.Server/Api/StatusApiServer.cs
+++ b/Source/ACE.Server/Api/StatusApiServer.cs
@@ -45,7 +45,9 @@ namespace ACE.Server.Api
         private static DateTime _lastCleanup = DateTime.UtcNow;
 
         private static FileSystemWatcher? _watcher;
-        private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+        private static readonly ILog log =
+            LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod()?.DeclaringType
+                                 ?? typeof(StatusApiServer));
 
         public static void Start()
         {


### PR DESCRIPTION
## Summary
- handle null when initializing `log` in `StatusApiServer`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68488b5194808330bb62808957c99e26