### PR TITLE
Limit API console output

### DIFF
--- a/Source/ACE.Server/Api/StatusApiServer.cs
+++ b/Source/ACE.Server/Api/StatusApiServer.cs
@@ -232,6 +232,7 @@ namespace ACE.Server.Api
         {
             if (_app != null && _cts != null)
             {
+                log.Info("Stopping StatusApiServer...");
                 _cts.Cancel();
                 await _app.StopAsync();
                 _watcher?.Dispose();

--- a/Source/ACE.Server/log4net.config.docker
+++ b/Source/ACE.Server/log4net.config.docker
@@ -20,7 +20,21 @@
     <layout type="log4net.Layout.PatternLayout">
       <conversionPattern value="%date %-5level: %message%newline" />
     </layout>
-    <threshold value="INFO" />
+  </appender>
+
+  <appender name="StartupShutdownForwarder" type="log4net.Appender.ForwardingAppender">
+    <filter type="log4net.Filter.StringMatchFilter">
+      <stringToMatch value="Starting StatusApiServer" />
+    </filter>
+    <filter type="log4net.Filter.StringMatchFilter">
+      <stringToMatch value="Stopping StatusApiServer" />
+    </filter>
+    <filter type="log4net.Filter.LevelRangeFilter">
+      <levelMin value="ERROR" />
+      <levelMax value="FATAL" />
+    </filter>
+    <filter type="log4net.Filter.DenyAllFilter" />
+    <appender-ref ref="Console" />
   </appender>
 
   <appender name="RollingFileAppender" type="log4net.Appender.RollingFileAppender">
@@ -41,7 +55,7 @@
   </logger>
 
   <appender name="asyncForwarder" type="Log4Net.Async.AsyncForwardingAppender,Log4Net.Async">
-    <appender-ref ref="Console" />
+    <appender-ref ref="StartupShutdownForwarder" />
     <appender-ref ref="RollingFileAppender" />
   </appender>
 

--- a/Source/ACE.Server/log4net.config.example
+++ b/Source/ACE.Server/log4net.config.example
@@ -20,7 +20,21 @@
     <layout type="log4net.Layout.PatternLayout">
       <conversionPattern value="%date %-5level: %message%newline" />
     </layout>
-    <threshold value="INFO" />
+  </appender>
+
+  <appender name="StartupShutdownForwarder" type="log4net.Appender.ForwardingAppender">
+    <filter type="log4net.Filter.StringMatchFilter">
+      <stringToMatch value="Starting StatusApiServer" />
+    </filter>
+    <filter type="log4net.Filter.StringMatchFilter">
+      <stringToMatch value="Stopping StatusApiServer" />
+    </filter>
+    <filter type="log4net.Filter.LevelRangeFilter">
+      <levelMin value="ERROR" />
+      <levelMax value="FATAL" />
+    </filter>
+    <filter type="log4net.Filter.DenyAllFilter" />
+    <appender-ref ref="Console" />
   </appender>
 
   <appender name="RollingFileAppender" type="log4net.Appender.RollingFileAppender">
@@ -41,7 +55,7 @@
   </logger> 
 
   <appender name="asyncForwarder" type="Log4Net.Async.AsyncForwardingAppender,Log4Net.Async">
-    <appender-ref ref="Console" />
+    <appender-ref ref="StartupShutdownForwarder" />
     <appender-ref ref="RollingFileAppender" />
   </appender>
 


### PR DESCRIPTION
## Summary
- add shutdown log message in `StatusApiServer.StopAsync`
- restrict console logging to startup/shutdown and errors via forwarding appender

## Testing
- `dotnet` was not available so tests could not be run

------
https://chatgpt.com/codex/tasks/task_e_68499c3327a88330968990d3a3730227