### PR TITLE
Force HTTP/1.1 for plain status API traffic

### DIFF
--- a/Source/ACE.Server/Api/StatusApiServer.cs
+++ b/Source/ACE.Server/Api/StatusApiServer.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 using System.Net;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
@@ -102,6 +103,10 @@ namespace ACE.Server.Api
                     {
                         listenOptions.UseHttps(ConfigManager.Config.Server.Api.CertificatePath,
                                               ConfigManager.Config.Server.Api.CertificatePassword);
+                    }
+                    else
+                    {
+                        listenOptions.Protocols = HttpProtocols.Http1;
                     }
                 });
             });


### PR DESCRIPTION
## Summary
- lock StatusApiServer to HTTP/1.1 when `UseHttps` is disabled

## Testing
- `dotnet test --no-build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68503a853358833080aa15c5b878b0b0