### PR TITLE
Update runsettings framework

### DIFF
--- a/Source/test.runsettings
+++ b/Source/test.runsettings
@@ -11,7 +11,7 @@
     <TargetPlatform>x64</TargetPlatform>
 
     <!-- Framework35 | [Framework40] | Framework45 -->
-    <TargetFrameworkVersion>Framework45</TargetFrameworkVersion>
+    <TargetFrameworkVersion>net8.0</TargetFrameworkVersion>
 
   </RunConfiguration>
   


### PR DESCRIPTION
## Summary
- Updated the test configuration so that tests run using the .NET 8.0 target framework instead of the outdated Framework45 setting