### PR TITLE
Fix start_server.bat path for net8 build

### DIFF
--- a/Source/ACE.Server/start_server.bat
+++ b/Source/ACE.Server/start_server.bat
@@ -1,4 +1,7 @@
 @cd %~dp0
-@if not exist "ACE.Server.dll" (echo please run the copy of this file residing in the output folder: .\bin\x64\XXXXX\netcoreapp2.2\
-pause)
+@if not exist "ACE.Server.dll" (
+    echo please run the copy of this file residing in the build output directory, e.g. .\bin\x64\<Configuration>\net8.0\
+    pause
+    exit /b
+)
 dotnet ACE.Server.dll


### PR DESCRIPTION
## Summary
- Fix the hint in `start_server.bat` so it references the net8 build folder
- Add early exit if the batch file isn't run from the build output