### PR TITLE
Adjust startup tests to prefer existing config

### DIFF
--- a/Source/ACE.Server.Tests/StarterGearTests.cs
+++ b/Source/ACE.Server.Tests/StarterGearTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 
 using Newtonsoft.Json;
@@ -14,7 +15,9 @@ namespace ACE.Server.Tests
         [TestMethod]
         public void CanParseStarterGearJson()
         {
-            string contents = File.ReadAllText("../../../../../ACE.Server/starterGear.json");
+            var testDir = AppContext.BaseDirectory;
+            var starterGearPath = Path.GetFullPath(Path.Combine(testDir, "..", "..", "..", "ACE.Server", "starterGear.json"));
+            string contents = File.ReadAllText(starterGearPath);
 
             StarterGearConfiguration config = JsonConvert.DeserializeObject<StarterGearConfiguration>(contents);
         }

--- a/Source/ACE.Server.Tests/StartupTests.cs
+++ b/Source/ACE.Server.Tests/StartupTests.cs
@@ -16,7 +16,14 @@ namespace ACE.Server.Tests
         public static void TestSetup(TestContext context)
         {
             // copy config.js and initialize configuration
-            File.Copy(Path.Combine(Environment.CurrentDirectory, "..\\..\\..\\..\\..\\ACE.Server\\Config.js"), ".\\Config.js", true);
+            var testDir = AppContext.BaseDirectory;
+            var serverDir = Path.GetFullPath(Path.Combine(testDir, "..", "..", "..", "..", "ACE.Server"));
+            var configSource = Path.Combine(serverDir, "Config.js");
+
+            if (!File.Exists(configSource))
+                configSource = Path.Combine(serverDir, "Config.js.example");
+
+            File.Copy(configSource, Path.Combine(testDir, "Config.js"), true);
             ConfigManager.Initialize();
         }
 


### PR DESCRIPTION
## Summary
- use an existing `Config.js` if present when initializing server tests

## Testing
- `dotnet test Source/ACE.Server.Tests/ACE.Server.Tests.csproj --no-build -v n` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685acd022fe08330a4afb4b67d022f70