### PR TITLE
Add async login database operations

### DIFF
--- a/Source/ACE.Database/Models/Auth/AccountExtensions.cs
+++ b/Source/ACE.Database/Models/Auth/AccountExtensions.cs
@@ -5,6 +5,7 @@ using log4net;
 using System;
 using System.Linq;
 using System.Net;
+using System.Threading.Tasks;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -112,6 +113,15 @@ namespace ACE.Database.Models.Auth
             DatabaseManager.Authentication.UpdateAccount(account);
         }
 
+        public static async Task UpdateLastLoginAsync(this Account account, IPAddress address)
+        {
+            account.LastLoginIP = address.GetAddressBytes();
+            account.LastLoginTime = DateTime.UtcNow;
+            account.TotalTimesLoggedIn++;
+
+            await DatabaseManager.Authentication.UpdateAccountAsync(account);
+        }
+
         public static void UnBan(this Account account)
         {
             account.BanExpireTime = null;
@@ -120,6 +130,16 @@ namespace ACE.Database.Models.Auth
             account.BanReason = null;
 
             DatabaseManager.Authentication.UpdateAccount(account);
+        }
+
+        public static async Task UnBanAsync(this Account account)
+        {
+            account.BanExpireTime = null;
+            account.BannedByAccountId = null;
+            account.BannedTime = null;
+            account.BanReason = null;
+
+            await DatabaseManager.Authentication.UpdateAccountAsync(account);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add async EF Core helpers in `AuthenticationDatabase`
- support async account updates in extension methods
- refactor `AuthenticationHandler` to await async login operations

## Testing
- `dotnet test Source/ACE.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c16e8c5e88330a7dee3fccd5a6c2e