### PR TITLE
Implement async inventory loading

### DIFF
--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionLoginComplete.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionLoginComplete.cs
@@ -10,6 +10,9 @@ namespace ACE.Server.Network.GameAction.Actions
         [GameAction(GameActionType.LoginComplete)]
         public static void Handle(ClientMessage message, Session session)
         {
+            if (session.Player.AwaitingInventory)
+                return;
+
             session.Player.OnTeleportComplete();
 
             if (!session.Player.FirstEnterWorldDone)

--- a/Source/ACE.Server/WorldObjects/Container.cs
+++ b/Source/ACE.Server/WorldObjects/Container.cs
@@ -123,7 +123,7 @@ namespace ACE.Server.WorldObjects
         }
 
 
-        public bool InventoryLoaded { get; private set; }
+        public bool InventoryLoaded { get; internal set; }
 
         /// <summary>
         /// This will contain all main pack items, and all side slot items.<para />

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -46,6 +46,12 @@ namespace ACE.Server.WorldObjects
 
         public bool LastContact = true;
 
+        /// <summary>
+        /// True while the server is waiting for this player's possessions
+        /// to load from the database during login.
+        /// </summary>
+        public bool AwaitingInventory { get; internal set; }
+
         public bool IsJumping
         {
             get


### PR DESCRIPTION
## Summary
- create awaiting inventory flag on Player
- expose Container.InventoryLoaded setter for WorldManager
- load player immediately without possessions and fetch inventory asynchronously
- avoid calling OnTeleportComplete until possessions arrive
- guard LoginComplete handler with awaiting inventory check
