### PR TITLE
Add Linux start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,11 @@ Please note that this project is released with a [Contributor Code of Conduct](h
 
 ## Contact
 * [Discord Channel](https://discord.gg/C2WzhP9)
+
+## Server Startup Scripts
+After building, run the appropriate script from the build output directory:
+
+* `start_server.bat` for Windows
+* `start_server.sh` for Linux/macOS
+
+Each script verifies it is executed from the output folder and then launches the server using `dotnet`.

--- a/Source/ACE.Server/ACE.Server.csproj
+++ b/Source/ACE.Server/ACE.Server.csproj
@@ -279,6 +279,9 @@
     <None Update="start_server.bat">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="start_server.sh">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/ACE.Server/start_server.sh
+++ b/Source/ACE.Server/start_server.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+cd "$(dirname "$0")"
+if [ ! -f "ACE.Server.dll" ]; then
+    echo "please run the copy of this file residing in the build output directory, e.g. ./bin/x64/<Configuration>/net8.0/"
+    read -r -p "Press enter to exit..." _
+    exit 1
+fi
+exec dotnet ACE.Server.dll
+


### PR DESCRIPTION
## Summary
- add `start_server.sh` for linux/macOS
- copy the new script in the project like the existing `.bat`
- document the scripts in the README

## Testing
- `dotnet test Source/ACE.sln --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c6944ed08833090941069c610a994